### PR TITLE
Remove deepsource auto format, add sonarlint for vscode

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -8,4 +8,4 @@ name = "java"
 
 [[transformers]]
 name = "google-java-format"
-enabled = true
+enabled = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
     "recommendations": [
-        "redhat.java"
+        "redhat.java",
+        "SonarSource.sonarlint-vscode"
     ]
 }


### PR DESCRIPTION
While I don't agree with your opinion that auto formatting code is dangerous, I went ahead and removed it.

Personally, I don't believe that a multi-billion dollar corporation with some of the smartest software engineers in the world would use a tool internally that had the chance to break their production code base (the same tool that we--and thousands other open source projects--are using) To me, it is important that we have a consistent format to improve readability, and not to mention the fact that IDE formatters require you to press a button meaning that formatting could be forgotten and merged without it. Please know this isn't an attack on your judgement, just rather the opinions of Rowan and I.

The deepsource:java check is just to ensure that the code builds properly before allowing merging.